### PR TITLE
Fix linux build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = git://git.openssl.org/openssl.git
 [submodule "openvpn-build"]
 	path = openvpn-build
-	url = git@github.com:mullvad/openvpn-build.git
+	url = https://github.com/mullvad/openvpn-build.git

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ openvpn: lz4 lzo openssl
 	$(MAKE) clean ; \
 	$(MAKE) ; \
 	$(MAKE) install
+	strip $(BUILD_DIR)/sbin/openvpn
 
 windows: clean
 	rm -r "$(WINDOWS_BUILDROOT)"

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,9 @@ LZO_VERSION = lzo-2.10
 LZO_CONFIG = --enable-static --disable-debug
 
 
-# Here platforms can append specific generic make parameters if needed
-MAKE_EXTRA_ARGS =
-
 # You likely need GNU Make for this to work.
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-	MAKE_EXTRA_ARGS += LIBS="-all-static"
 	OPENSSL_CONFIG += -static
 	SHARED_LIB_EXT = so*
 endif
@@ -52,7 +48,7 @@ lz4:
 	mkdir -p $(BUILD_DIR)
 	cd lz4 ; \
 	$(MAKE) clean ; \
-	PREFIX=$(BUILD_DIR) $(MAKE) install $(MAKE_EXTRA_ARGS)
+	PREFIX=$(BUILD_DIR) $(MAKE) install LIBS="-all-static"
 	# lz4 always installs a shared library. Unless it's removed
 	# OpenVPN will link against it.
 	rm $(BUILD_DIR)/lib/liblz4.*$(SHARED_LIB_EXT)
@@ -94,7 +90,7 @@ openvpn: lz4 lzo openssl
 		LZO_LIBS="-L$(BUILD_DIR)/lib -llzo2" \
 		LZ4_LIBS="-L$(BUILD_DIR)/lib -llz4" ; \
 	make clean ; \
-	make $(MAKE_EXTRA_ARGS) ; \
+	make ; \
 	make install
 
 windows: clean

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ lzo:
 	tar xzf $(LZO_VERSION).tar.gz
 	cd $(LZO_VERSION) ; \
 	./configure --prefix=$(BUILD_DIR) $(LZO_CONFIG) ; \
-	make ; \
-	make install
+	$(MAKE) ; \
+	$(MAKE) install
 
 openssl:
 	@echo "Building OpenSSL"
@@ -71,9 +71,9 @@ openssl:
 		--prefix=$(BUILD_DIR) \
 		--openssldir=$(BUILD_DIR) \
 		$(OPENSSL_CONFIG) ; \
-	make clean ; \
-	make build_libs build_apps ; \
-	make install_sw
+	$(MAKE) clean ; \
+	$(MAKE) build_libs build_apps ; \
+	$(MAKE) install_sw
 
 openvpn: lz4 lzo openssl
 	@echo "Building OpenVPN"
@@ -89,9 +89,9 @@ openvpn: lz4 lzo openssl
 		OPENSSL_LIBS="-L$(BUILD_DIR)/lib -lssl -lcrypto" \
 		LZO_LIBS="-L$(BUILD_DIR)/lib -llzo2" \
 		LZ4_LIBS="-L$(BUILD_DIR)/lib -llz4" ; \
-	make clean ; \
-	make ; \
-	make install
+	$(MAKE) clean ; \
+	$(MAKE) ; \
+	$(MAKE) install
 
 windows: clean
 	rm -r "$(WINDOWS_BUILDROOT)"


### PR DESCRIPTION
So the Linux build could not load plugins, which was a bummer. Making it not all static solves this, and the few things it now dynamically links to can be expected to exist everywhere (?)

I suspect it's possible to statically link in these system libraries as well and keep the dynamic loading support, but since it feels like these will always be available anyway I did not spend time on figuring that out. Suggestions for how is welcome if you feel it's a priority.

```bash
$ ldd build/sbin/openvpn 
	linux-vdso.so.1 (0x00007ffc2e5be000)
	libnsl.so.1 => /lib/x86_64-linux-gnu/libnsl.so.1 (0x00007bbff20f9000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007bbff1ee2000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007bbff1cde000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007bbff1ac1000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007bbff1722000)
	/lib64/ld-linux-x86-64.so.2 (0x00007bbff2866000)

$ file build/sbin/openvpn 
build/sbin/openvpn: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, BuildID[sha1]=f7dd9610ab51d992c26e6d9d8b3d7e475365c22e, stripped
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-binaries/6)
<!-- Reviewable:end -->
