### PR TITLE
wireguard-go: use proper Go modules instead of git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "libnftnl"]
 	path = libnftnl
 	url = git://git.netfilter.org/libnftnl
-[submodule "wireguard-go/wireguard-go"]
-	path = wireguard-go/wireguard-go
-	url = https://git.zx2c4.com/wireguard-go/
 [submodule "libsodium"]
 	path = libsodium
 	url = https://github.com/jedisct1/libsodium.git

--- a/Makefile
+++ b/Makefile
@@ -153,11 +153,9 @@ libnftnl: libmnl
 
 wireguard-go:
 	@echo "Building wireguard-go"
-	rm wireguard-go/wireguard-go/donotuseon_linux.go || true
-	cp wireguard-go/libwg.go wireguard-go/wireguard-go/
-	cd wireguard-go/wireguard-go; \
-  go build -v -o libwg.a -buildmode c-archive
-	cp wireguard-go/wireguard-go/libwg.a $(TARGET_OUTPUT_DIR)
+	cd wireguard-go && \
+	go build -v -o libwg.a -buildmode c-archive
+	cp wireguard-go/libwg.a $(TARGET_OUTPUT_DIR)
 
 libsodium:
 	@echo "Building libsodium"

--- a/wireguard-go/go.mod
+++ b/wireguard-go/go.mod
@@ -1,0 +1,8 @@
+module github.com/mullvad/mullvadvpn-app-binaries/wireguard-go
+
+go 1.12
+
+require (
+	golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc
+	golang.zx2c4.com/wireguard v0.0.0-20190321212009-317d716d662f
+)

--- a/wireguard-go/go.sum
+++ b/wireguard-go/go.sum
@@ -1,0 +1,13 @@
+github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576 h1:aUX/1G2gFSs4AsJJg2cL3HuoRhCSCz733FE5GUSuaT4=
+golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53 h1:kcXqo9vE6fsZY5X5Rd7R1l7fTgnWaDCVmln65REefiE=
+golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc h1:4gbWbmmPFp4ySWICouJl6emP0MyS31yy9SrTlAGFT+g=
+golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.zx2c4.com/wireguard v0.0.0-20190321212009-317d716d662f h1:Bb84l+RH8cyXF2WTRUjuPVGZ61FlpH+7xbETmSaX3sI=
+golang.zx2c4.com/wireguard v0.0.0-20190321212009-317d716d662f/go.mod h1:u0Cl3X+pyWdXaax3S583DQrnGDuTASO0QdlKFrs8r/8=


### PR DESCRIPTION
Instead of having to do the insane submodule hack like before,
wireguard-go has finally gotten with the times and uses a proper Go
module with source code pinning via hashes (updatable with go-get). This
enables you to use the latest wireguard-go improvements, as well as Go
1.12.

This commit is entirely untested, but it appears to compile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-binaries/16)
<!-- Reviewable:end -->
