### PR TITLE
wireguard-go: relicense to MIT

### DIFF
--- a/wireguard-go/libwg.go
+++ b/wireguard-go/libwg.go
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0
+/* SPDX-License-Identifier: MIT
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */


### PR DESCRIPTION
This project seems to statically link to OpenVPN, which is GPL-2.0.
IANAL, but I'm pretty sure Apache-2.0 and GPL-2.0 don't get along
especially well, and this might lead to problems.

Since I'm the sole copyright listed on this file, it's easy enough to
just relicense it to a super liberal license, MIT, that mostly gets
along with everything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-binaries/18)
<!-- Reviewable:end -->
