### PR TITLE
Always build libwg.so for Android from scratch

### DIFF
--- a/android-build/build.sh
+++ b/android-build/build.sh
@@ -18,5 +18,6 @@ popd
 
 # Build Wireguard-Go
 pushd wireguard-go/
+make -f Android.mk clean
 make -f Android.mk
 popd

--- a/wireguard-go/Android.mk
+++ b/wireguard-go/Android.mk
@@ -47,3 +47,6 @@ $(DESTDIR)/libwg.so: $(GOROOT)/bin/go
 	chmod -fR +w "$(GOPATH)/pkg/mod"
 	go build -tags "linux android" -ldflags="-X main.socketDirectory=/data/data/$(ANDROID_PACKAGE_NAME)/cache/wireguard" -v -o "$@" -buildmode c-shared
 	go version > $(BUILDDIR)/.gobuildversion
+
+clean:
+	rm -f $(DESTDIR)/libwg.so


### PR DESCRIPTION
This PR adds a `clean` target to `wireguard-go`'s makefile for Android, that just removes the output shared library.

The target is then used in the build script so that every Android build using the script builds `libwg.so` from scratch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-binaries/29)
<!-- Reviewable:end -->
