### PR TITLE
Upgrade NDK version

### DIFF
--- a/android-build/Dockerfile
+++ b/android-build/Dockerfile
@@ -11,19 +11,19 @@ RUN apt-get update -y && apt-get install -y \
 
 # Install Android NDK
 RUN cd /tmp && \
-    curl -sf -L -O https://dl.google.com/android/repository/android-ndk-r19b-linux-x86_64.zip && \
-    test $(sha256sum android-ndk-r19b-linux-x86_64.zip | cut -f1 -d' ') = "0fbb1645d0f1de4dde90a4ff79ca5ec4899c835e729d692f433fda501623257a" && \
+    curl -sf -L -O https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip && \
+    test $(sha256sum android-ndk-r20-linux-x86_64.zip | cut -f1 -d' ') = "57435158f109162f41f2f43d5563d2164e4d5d0364783a9a6fab3ef12cb06ce0" && \
     mkdir /opt/android && \
     cd /opt/android && \
-    unzip -q /tmp/android-ndk-r19b-linux-x86_64.zip && \
-    rm /tmp/android-ndk-r19b-linux-x86_64.zip && \
+    unzip -q /tmp/android-ndk-r20-linux-x86_64.zip && \
+    rm /tmp/android-ndk-r20-linux-x86_64.zip && \
     mkdir toolchains && \
-    /opt/android/android-ndk-r19b/build/tools/make-standalone-toolchain.sh --platform=android-28 --arch=arm64 --install-dir=/opt/android/toolchains/android28-aarch64
+    /opt/android/android-ndk-r20/build/tools/make-standalone-toolchain.sh --platform=android-28 --arch=arm64 --install-dir=/opt/android/toolchains/android28-aarch64
 
 ENV ANDROID_SYSROOT="/opt/android/toolchains/android28-aarch64/sysroot" \
     ANDROID_LLVM_TRIPLE="aarch64-linux-android" \
     ANDROID_C_COMPILER="/opt/android/toolchains/android28-aarch64/bin/aarch64-linux-android28-clang" \
-    ANDROID_NDK_HOME="/opt/android/android-ndk-r19b" \
+    ANDROID_NDK_HOME="/opt/android/android-ndk-r20" \
     ANDROID_TOOLCHAIN_ROOT="/opt/android/toolchains/android28-aarch64" \
     ANDROID_ARCH_NAME="arm64"
 


### PR DESCRIPTION
This PR updates the NDK version in the Docker build image to `r20`, which is the same version recommended for building the app in the main repository.

Binaries haven't been rebuilt because they will also be rebuilt on the next PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-binaries/30)
<!-- Reviewable:end -->
