### PR TITLE
Optimize android docker image

### DIFF
--- a/android-build/Dockerfile
+++ b/android-build/Dockerfile
@@ -16,38 +16,31 @@ RUN cd /tmp && \
     mkdir /opt/android && \
     cd /opt/android && \
     unzip -q /tmp/android-ndk-r20-linux-x86_64.zip && \
-    rm /tmp/android-ndk-r20-linux-x86_64.zip && \
-    mkdir toolchains && \
-    /opt/android/android-ndk-r20/build/tools/make-standalone-toolchain.sh --platform=android-21 --arch=arm64 --install-dir=/opt/android/toolchains/android21-aarch64 && \
-    /opt/android/android-ndk-r20/build/tools/make-standalone-toolchain.sh --platform=android-21 --arch=x86_64 --install-dir=/opt/android/toolchains/android21-x86_64 && \
-    /opt/android/android-ndk-r20/build/tools/make-standalone-toolchain.sh --platform=android-21 --arch=arm --install-dir=/opt/android/toolchains/android21-armv7 && \
-    /opt/android/android-ndk-r20/build/tools/make-standalone-toolchain.sh --platform=android-21 --arch=x86 --install-dir=/opt/android/toolchains/android21-i686
+    rm /tmp/android-ndk-r20-linux-x86_64.zip
+
 
 ENV ANDROID_NDK_HOME="/opt/android/android-ndk-r20"
 
-# Create symlinks to some libraries so that the linker used by Go can find them
-RUN for arch in aarch64 x86_64 i686 armv7; do \
-        if [ "$arch" = "armv7" ]; then \
-            TARGET="arm-linux-androideabi"; \
-        else \
-            TARGET="${arch}-linux-android"; \
-        fi; \
-        \
-        for lib in crtbegin_dynamic.o crtend_android.o crtbegin_so.o crtend_so.o; do \
-            ln -s "/opt/android/toolchains/android21-${arch}/sysroot/usr/lib/${TARGET}/21/$lib" /opt/android/toolchains/android21-${arch}/sysroot/usr/lib/${TARGET}/; \
-        done \
-    done
 
-# Install Go-lang
+# Install Go-lang and patch it to use the appropriate monotonic clock
+COPY goruntime-boottime-over-monotonic.diff /opt/goruntime-boottime-over-monotonic.diff
 RUN cd /tmp && \
-    curl -sf -L -O https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz && \
-    test $(sha256sum go1.12.7.linux-amd64.tar.gz | cut -f1 -d' ') = "66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9" && \
+    curl -sf -L -O https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && \
+    echo "0804bf02020dceaa8a7d7275ee79f7a142f1996bfd0c39216ccb405f93f994c0 go1.13.3.linux-amd64.tar.gz" | sha256sum --check && \
     cd /opt && \
-    tar -xzf /tmp/go1.12.7.linux-amd64.tar.gz && \
-    rm /tmp/go1.12.7.linux-amd64.tar.gz
+    tar -xzf /tmp/go1.13.3.linux-amd64.tar.gz && \
+    rm /tmp/go1.13.3.linux-amd64.tar.gz && \
+    patch -p1 -f -N -r- -d "/opt/go" < /opt/goruntime-boottime-over-monotonic.diff
 
 ENV PATH=${PATH}:/opt/go/bin
+ENV GOROOT=/opt/go
+ENV GOPATH=/opt/go-path
 
+RUN apt-get remove -y curl \
+    && apt-get autoremove -y
+
+COPY install-ndk-toolchain /usr/local/bin/install-ndk-toolchain
+RUN chmod +x /usr/local/bin/install-ndk-toolchain
 COPY build.sh /usr/local/bin/build.sh
 
 ENTRYPOINT ["/usr/local/bin/build.sh"]

--- a/android-build/build.sh
+++ b/android-build/build.sh
@@ -5,46 +5,31 @@ set -e
 for arch in arm arm64 x86_64 x86; do
     case "$arch" in
         "arm64")
-            export ANDROID_LLVM_TRIPLE="aarch64-linux-android"
-            export ANDROID_LIB_TRIPLE="aarch64-linux-android"
             export RUST_TARGET_TRIPLE="aarch64-linux-android"
-            export RUST_LLVM_ARCH="aarch64"
             ;;
         "x86_64")
-            export ANDROID_LLVM_TRIPLE="x86_64-linux-android"
-            export ANDROID_LIB_TRIPLE="x86_64-linux-android"
             export RUST_TARGET_TRIPLE="x86_64-linux-android"
-            export RUST_LLVM_ARCH="x86_64"
             ;;
         "arm")
-            export ANDROID_LLVM_TRIPLE="armv7a-linux-androideabi"
-            export ANDROID_LIB_TRIPLE="arm-linux-androideabi"
             export RUST_TARGET_TRIPLE="armv7-linux-androideabi"
-            export RUST_LLVM_ARCH="armv7"
             ;;
         "x86")
-            export ANDROID_LLVM_TRIPLE="i686-linux-android"
-            export ANDROID_LIB_TRIPLE="i686-linux-android"
             export RUST_TARGET_TRIPLE="i686-linux-android"
-            export RUST_LLVM_ARCH="i686"
             ;;
     esac
 
-    export ANDROID_ARCH_NAME="$arch"
-    export ANDROID_TOOLCHAIN_ROOT="/opt/android/toolchains/android21-${RUST_LLVM_ARCH}"
-    export ANDROID_SYSROOT="${ANDROID_TOOLCHAIN_ROOT}/sysroot"
-    export ANDROID_C_COMPILER="${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_LLVM_TRIPLE}21-clang"
+    eval "$(install-ndk-toolchain $arch)"
 
     # Build OpenSSL
     export PATH="$PATH:${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
 
     OPENSSL_CONFIG="no-weak-ssl-ciphers no-ssl3 no-ssl3-method no-bf no-rc2 no-rc4 no-rc5 no-md4 no-seed no-cast no-camellia no-idea enable-rfc3779"
-    if echo "$ANDROID_ARCH_NAME" | grep -q 64; then
+    if echo "$arch" | grep -q 64; then
         OPENSSL_CONFIG+=" enable-ec_nistp_64_gcc_128"
     fi
 
     pushd openssl
-    ./Configure "android-$ANDROID_ARCH_NAME" -D__ANDROID_API__=21 no-shared -static --prefix=/opt/openssl --openssldir=/opt/openssl ${OPENSSL_CONFIG}
+    ./Configure "android-$arch" -D__ANDROID_API__=21 no-shared -static --prefix=/opt/openssl --openssldir=/opt/openssl ${OPENSSL_CONFIG}
     make clean
     make build_libs
 

--- a/android-build/goruntime-boottime-over-monotonic.diff
+++ b/android-build/goruntime-boottime-over-monotonic.diff
@@ -1,0 +1,161 @@
+From b19623e7673a4d6743745382d5d38751b64e011d Mon Sep 17 00:00:00 2001
+From: "Jason A. Donenfeld" <Jason@zx2c4.com>
+Date: Wed, 27 Feb 2019 05:05:44 +0100
+Subject: [PATCH] runtime: use CLOCK_BOOTTIME in nanotime on Linux
+
+This makes timers account for having expired while a computer was
+asleep, which is quite common on mobile devices. Note that BOOTTIME is
+identical to MONOTONIC, except that it takes into account time spent
+in suspend. In Linux 4.17, the kernel will actually make MONOTONIC act
+like BOOTTIME anyway, so this switch will additionally unify the
+timer behavior across kernels.
+
+BOOTTIME was introduced into Linux 2.6.39-rc1 with 70a08cca1227d in
+2011.
+
+Fixes #24595
+
+Change-Id: I7b2a6ca0c5bc5fce57ec0eeafe7b68270b429321
+---
+ src/runtime/sys_linux_386.s     | 4 ++--
+ src/runtime/sys_linux_amd64.s   | 2 +-
+ src/runtime/sys_linux_arm.s     | 4 ++--
+ src/runtime/sys_linux_arm64.s   | 4 ++--
+ src/runtime/sys_linux_mips64x.s | 2 +-
+ src/runtime/sys_linux_mipsx.s   | 2 +-
+ src/runtime/sys_linux_ppc64x.s  | 2 +-
+ src/runtime/sys_linux_s390x.s   | 2 +-
+ 8 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/src/runtime/sys_linux_386.s b/src/runtime/sys_linux_386.s
+index 72c43bd9da..daadfe32a9 100644
+--- a/src/runtime/sys_linux_386.s
++++ b/src/runtime/sys_linux_386.s
+@@ -288,13 +288,13 @@ noswitch:
+ 
+ 	LEAL	8(SP), BX	// &ts (struct timespec)
+ 	MOVL	BX, 4(SP)
+-	MOVL	$1, 0(SP)	// CLOCK_MONOTONIC
++	MOVL	$7, 0(SP)	// CLOCK_BOOTTIME
+ 	CALL	AX
+ 	JMP finish
+ 
+ fallback:
+ 	MOVL	$SYS_clock_gettime, AX
+-	MOVL	$1, BX		// CLOCK_MONOTONIC
++	MOVL	$7, BX		// CLOCK_BOOTTIME
+ 	LEAL	8(SP), CX
+ 	INVOKE_SYSCALL
+ 
+diff --git a/src/runtime/sys_linux_amd64.s b/src/runtime/sys_linux_amd64.s
+index 5c300f553d..e4a6f12ec6 100644
+--- a/src/runtime/sys_linux_amd64.s
++++ b/src/runtime/sys_linux_amd64.s
+@@ -261,7 +261,7 @@ noswitch:
+ 	MOVQ	runtime·vdsoClockgettimeSym(SB), AX
+ 	CMPQ	AX, $0
+ 	JEQ	fallback
+-	MOVL	$1, DI // CLOCK_MONOTONIC
++	MOVL	$7, DI // CLOCK_BOOTTIME
+ 	LEAQ	0(SP), SI
+ 	CALL	AX
+ 	MOVQ	0(SP), AX	// sec
+diff --git a/src/runtime/sys_linux_arm.s b/src/runtime/sys_linux_arm.s
+index 9c7398451c..61b6cd91f6 100644
+--- a/src/runtime/sys_linux_arm.s
++++ b/src/runtime/sys_linux_arm.s
+@@ -11,7 +11,7 @@
+ #include "textflag.h"
+ 
+ #define CLOCK_REALTIME	0
+-#define CLOCK_MONOTONIC	1
++#define CLOCK_BOOTTIME	7
+ 
+ // for EABI, as we don't support OABI
+ #define SYS_BASE 0x0
+@@ -291,7 +291,7 @@ noswitch:
+ 	SUB	$24, R13	// Space for results
+ 	BIC	$0x7, R13	// Align for C code
+ 
+-	MOVW	$CLOCK_MONOTONIC, R0
++	MOVW	$CLOCK_BOOTTIME, R0
+ 	MOVW	$8(R13), R1	// timespec
+ 	MOVW	runtime·vdsoClockgettimeSym(SB), R11
+ 	CMP	$0, R11
+diff --git a/src/runtime/sys_linux_arm64.s b/src/runtime/sys_linux_arm64.s
+index 2835b6ca1c..346ca9cfce 100644
+--- a/src/runtime/sys_linux_arm64.s
++++ b/src/runtime/sys_linux_arm64.s
+@@ -13,7 +13,7 @@
+ #define AT_FDCWD -100
+ 
+ #define CLOCK_REALTIME 0
+-#define CLOCK_MONOTONIC 1
++#define CLOCK_BOOTTIME 7
+ 
+ #define SYS_exit		93
+ #define SYS_read		63
+@@ -247,7 +247,7 @@ noswitch:
+ 	BIC	$15, R1
+ 	MOVD	R1, RSP
+ 
+-	MOVW	$CLOCK_MONOTONIC, R0
++	MOVW	$CLOCK_BOOTTIME, R0
+ 	MOVD	runtime·vdsoClockgettimeSym(SB), R2
+ 	CBZ	R2, fallback
+ 	BL	(R2)
+diff --git a/src/runtime/sys_linux_mips64x.s b/src/runtime/sys_linux_mips64x.s
+index 33ed1050c2..59a5be179c 100644
+--- a/src/runtime/sys_linux_mips64x.s
++++ b/src/runtime/sys_linux_mips64x.s
+@@ -189,7 +189,7 @@ TEXT runtime·walltime(SB),NOSPLIT,$16
+ 	RET
+ 
+ TEXT runtime·nanotime(SB),NOSPLIT,$16
+-	MOVW	$1, R4 // CLOCK_MONOTONIC
++	MOVW	$7, R4 // CLOCK_BOOTTIME
+ 	MOVV	$0(R29), R5
+ 	MOVV	$SYS_clock_gettime, R2
+ 	SYSCALL
+diff --git a/src/runtime/sys_linux_mipsx.s b/src/runtime/sys_linux_mipsx.s
+index 6e539fbc6f..55b2bf7156 100644
+--- a/src/runtime/sys_linux_mipsx.s
++++ b/src/runtime/sys_linux_mipsx.s
+@@ -194,7 +194,7 @@ TEXT runtime·walltime(SB),NOSPLIT,$8-12
+ 	RET
+ 
+ TEXT runtime·nanotime(SB),NOSPLIT,$8-8
+-	MOVW	$1, R4	// CLOCK_MONOTONIC
++	MOVW	$7, R4	// CLOCK_BOOTTIME
+ 	MOVW	$4(R29), R5
+ 	MOVW	$SYS_clock_gettime, R2
+ 	SYSCALL
+diff --git a/src/runtime/sys_linux_ppc64x.s b/src/runtime/sys_linux_ppc64x.s
+index 13d23156bd..f67e5062aa 100644
+--- a/src/runtime/sys_linux_ppc64x.s
++++ b/src/runtime/sys_linux_ppc64x.s
+@@ -204,7 +204,7 @@ fallback:
+ 	JMP	finish
+ 
+ TEXT runtime·nanotime(SB),NOSPLIT,$16
+-	MOVD	$1, R3		// CLOCK_MONOTONIC
++	MOVD	$7, R3		// CLOCK_BOOTTIME
+ 
+ 	MOVD	R1, R15		// R15 is unchanged by C code
+ 	MOVD	g_m(g), R21	// R21 = m
+diff --git a/src/runtime/sys_linux_s390x.s b/src/runtime/sys_linux_s390x.s
+index 58b36dff0a..cb92e9a402 100644
+--- a/src/runtime/sys_linux_s390x.s
++++ b/src/runtime/sys_linux_s390x.s
+@@ -180,7 +180,7 @@ TEXT runtime·walltime(SB),NOSPLIT,$16
+ 	RET
+ 
+ TEXT runtime·nanotime(SB),NOSPLIT,$16
+-	MOVW	$1, R2 // CLOCK_MONOTONIC
++	MOVW	$7, R2 // CLOCK_BOOTTIME
+ 	MOVD	$tp-16(SP), R3
+ 	MOVW	$SYS_clock_gettime, R1
+ 	SYSCALL
+-- 
+2.23.0
+

--- a/android-build/install-ndk-toolchain
+++ b/android-build/install-ndk-toolchain
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -eu
+mkdir -p /opt/android/toolchains
+
+target_arch=$1
+
+case "$target_arch" in
+    "arm64")
+        export llvm_arch="aarch64-linux-android"
+        ;;
+    "x86_64")
+        export llvm_arch="x86_64-linux-android"
+        ;;
+    "arm")
+        export llvm_arch="arm-linux-androideabi"
+        ;;
+    "x86")
+        export llvm_arch="i686-linux-android"
+        ;;
+esac
+
+/opt/android/android-ndk-r20/build/tools/make-standalone-toolchain.sh \
+  --platform=android-21 \
+  --arch=$target_arch \
+  --install-dir=/opt/android/toolchains/android21-$target_arch \
+  1>&2
+
+for lib in crtbegin_dynamic.o crtend_android.o crtbegin_so.o crtend_so.o; do
+    ln -s "/opt/android/toolchains/android21-${target_arch}/sysroot/usr/lib/${llvm_arch}/21/$lib" \
+          "/opt/android/toolchains/android21-${target_arch}/sysroot/usr/lib/${llvm_arch}/" \
+          1>&2
+done
+
+ANDROID_TOOLCHAIN_ROOT="/opt/android/toolchains/android21-${target_arch}"
+ANDROID_SYSROOT="${ANDROID_TOOLCHAIN_ROOT}/sysroot"
+ANDROID_C_COMPILER="${ANDROID_TOOLCHAIN_ROOT}/bin/${llvm_arch}-clang"
+
+# outputing environment variables to be used for this toolchain
+echo export ANDROID_TOOLCHAIN_ROOT="\"$ANDROID_TOOLCHAIN_ROOT\""
+echo export ANDROID_SYSROOT="\"$ANDROID_SYSROOT\""
+echo export ANDROID_C_COMPILER="\"$ANDROID_C_COMPILER\""


### PR DESCRIPTION
I've changed the Dockerfile in two meaningful ways:
- the NDK toolchains are now installed lazily. This reduces the size of the image from 3 to 1 gigabytes when compressed. Scripts ran in the container should use `install-ndk-toolchain $arch` where `$arch` is any of the short architecture name for the NDK (`arm64,arm,x86,x86_64`).
- Setup and patch a `go` toolchain so that it doesn't have to be done every time `wireguard-go` has to be compiled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-binaries/60)
<!-- Reviewable:end -->
