### PR TITLE
Add configuarion for cross-compiling for Apple Silicon macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Building the OpenVPN binary should be as simple as running `make openvpn`.
 Currently, the Linux distro of choice for building OpenVPN currently is Debian
 9, issues have been experienced on other distributions.
 
+#### Building for ARM macOS
+
+Building for Apple Silicon macOS is done by cross-compiling from Intel macOS by adding the `TARGET="aarch64-apple-darwin"` option, i.e.:
+```bash
+make openvpn TARGET="aarch64-apple-darwin"
+```
+
 ### Building for Windows
 
 Building `openvpn.exe` for Windows is done by cross-compiling from Linux using
@@ -108,6 +115,13 @@ said tag is properly signed with the following key:
 
 ### Linux + MacOS
 To build Shadowsocks, just run `make shadowsocks_linux` or `make shadowsocks_macos` respectively.
+
+#### Building for ARM macOS
+
+Building for Apple Silicon macOS is done by cross-compiling from Intel macOS by adding the `TARGET="aarch64-apple-darwin"` option, i.e.:
+```bash
+make shadowsocks_macos TARGET="aarch64-apple-darwin"
+```
 
 ### Windows
 


### PR DESCRIPTION
This PR makes it possible to cross-compile for Apple Silicon macOS from Intel macOS. To accomplish this `openssl` had to be upgraded to at least `1.1.1i`. This PR updates OpenSSL to `1.1.1j`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-binaries/76)
<!-- Reviewable:end -->
