### PR TITLE
Enable DCO support on Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "openvpn"]
 	path = openvpn
 	url = https://github.com/mullvad/openvpn
-[submodule "lz4"]
-	path = lz4
-	url = https://github.com/lz4/lz4
 [submodule "openssl"]
 	path = openssl
 	url = git://git.openssl.org/openssl.git
@@ -22,3 +19,6 @@
 [submodule "wireguard-nt"]
 	path = wireguard-nt
 	url = https://github.com/mullvad/wireguard-nt
+[submodule "libnl"]
+	path = libnl
+	url = https://github.com/thom311/libnl

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ LABEL org.opencontainers.image.licenses=GPL-3.0
 RUN apt-get update -y && apt-get install -y \
     git curl wget unzip bzip2 \
     pkg-config make autoconf libtool \
+    libnl-genl-3-dev \
     gcc iproute2 \
     gcc-aarch64-linux-gnu \
     gcc-mingw-w64 mingw-w64-common \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ LABEL org.opencontainers.image.licenses=GPL-3.0
 RUN apt-get update -y && apt-get install -y \
     git curl wget unzip bzip2 \
     pkg-config make autoconf libtool \
-    libnl-genl-3-dev \
-    gcc iproute2 \
+    bison flex \
+    gcc \
     gcc-aarch64-linux-gnu \
     gcc-mingw-w64 mingw-w64-common \
     && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OPENSSL_CONFIG += no-autoload-config
 OPENVPN_VERSION = 2.6.0
 OPENVPN_CONFIG = --enable-static --disable-shared --disable-debug --disable-plugin-down-root \
 	--disable-management --disable-port-share --disable-systemd --disable-dependency-tracking \
-	--disable-pkcs11 --disable-plugin-auth-pam --enable-plugins \
+	--disable-pkcs11 --disable-plugin-auth-pam --enable-plugins --enable-dco \
 	--disable-lzo --disable-lz4 --enable-comp-stub
 
 LIBMNL_CONFIG = --enable-static --disable-shared
@@ -30,7 +30,7 @@ UNAME_M := $(shell uname -m)
 
 ifeq ($(UNAME_S),Linux)
 	PLATFORM_OPENSSL_CONFIG = -static
-	PLATFORM_OPENVPN_CONFIG = --enable-iproute2
+	PLATFORM_OPENVPN_CONFIG = --disable-iproute2
 	HOST = "$(UNAME_M)-unknown-linux-gnu"
 endif
 ifeq ($(UNAME_S),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OPENSSL_CONFIG += no-autoload-config
 OPENVPN_VERSION = 2.6.0
 OPENVPN_CONFIG = --enable-static --disable-shared --disable-debug --disable-plugin-down-root \
 	--disable-management --disable-port-share --disable-systemd --disable-dependency-tracking \
-	--disable-pkcs11 --disable-plugin-auth-pam --enable-plugins --enable-dco \
+	--disable-pkcs11 --disable-plugin-auth-pam --enable-plugins \
 	--disable-lzo --disable-lz4 --enable-comp-stub
 
 LIBMNL_CONFIG = --enable-static --disable-shared
@@ -30,7 +30,7 @@ UNAME_M := $(shell uname -m)
 
 ifeq ($(UNAME_S),Linux)
 	PLATFORM_OPENSSL_CONFIG = -static
-	PLATFORM_OPENVPN_CONFIG = --disable-iproute2
+	PLATFORM_OPENVPN_CONFIG = --enable-dco --disable-iproute2
 	HOST = "$(UNAME_M)-unknown-linux-gnu"
 endif
 ifeq ($(UNAME_S),Darwin)
@@ -69,7 +69,7 @@ else
 	LIBNFTNL_CFLAGS += -mcmodel=large
 endif
 
-.PHONY: help clean clean-build clean-submodules openssl openvpn openvpn_windows libmnl libnftnl
+.PHONY: help clean clean-build clean-submodules openssl openvpn openvpn_windows libmnl libnftnl libnl
 
 help:
 	@echo "Please run a more specific target"
@@ -99,16 +99,18 @@ openssl:
 	$(MAKE) build_libs build_apps ; \
 	$(MAKE) install_sw
 
-openvpn: openssl
+openvpn: openssl libnl
 	@echo "Building OpenVPN"
 	mkdir -p $(BUILD_DIR) $(TARGET)
 	cd openvpn ; \
 	export MACOSX_DEPLOYMENT_TARGET="$(MACOSX_DEPLOYMENT_TARGET)" ; \
 	export CFLAGS="$(CFLAGS)"; \
-	autoreconf -i -v ; \
+	autoreconf -f -i -v ; \
 	./configure \
 		--prefix=$(BUILD_DIR) \
 		$(OPENVPN_CONFIG) $(PLATFORM_OPENVPN_CONFIG) \
+		LIBNL_GENL_CFLAGS="-I$(PWD)/libnl/include" \
+		LIBNL_GENL_LIBS="-L$(PWD)/libnl/lib/.libs -lnl-genl-3" \
 		OPENSSL_CFLAGS="-I$(BUILD_DIR)/include" \
 		OPENSSL_LIBS="-L$(BUILD_DIR)/lib -lssl -lcrypto -lpthread -ldl" ; \
 	$(MAKE) clean ; \
@@ -137,6 +139,14 @@ openvpn_windows: clean-submodules
 		IMAGEROOT="$(BUILD_DIR)" \
 		./openvpn-build/generic/build
 	cp openvpn/src/openvpn/openvpn.exe ./x86_64-pc-windows-msvc/
+
+libnl:
+	@echo "Building libnl"
+	cd libnl; \
+	./autogen.sh; \
+	./configure --enable-static --disable-shared --enable-cli=no --disable-debug; \
+	$(MAKE) clean; \
+	$(MAKE)
 
 libmnl:
 	@echo "Building libmnl"

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Cross-compile both libraries on x64 Linux by setting the appropriate `TARGET`:
 ./container-run.sh make libnftnl TARGET="aarch64-unknown-linux-gnu"
 ```
 
+## libnl
+
+`libnl` is a dependency of OpenVPN, specifically DCO on Linux.
+When bumping the submodule, point to a release tag, and verify that the tag is signed by
+`49EA7C670E0850E7419514F629C2366E4DFC5728`.
+
 ## Updating Wintun
 
 Only applicable to Windows.


### PR DESCRIPTION
This also disables `iproute2`, as it's incompatible with DCO.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-binaries/102)
<!-- Reviewable:end -->
