### PR TITLE
openssl: Use GitHub "mirror"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,27 @@
 [submodule "openvpn"]
 	path = openvpn
-	url = https://github.com/mullvad/openvpn
+	url = https://github.com/mullvad/openvpn.git
 [submodule "openssl"]
 	path = openssl
-	url = git://git.openssl.org/openssl.git
+	url = https://github.com/openssl/openssl.git
 [submodule "openvpn-build"]
 	path = openvpn-build
 	url = https://github.com/mullvad/openvpn-build.git
 [submodule "libmnl"]
 	path = libmnl
-	url = git://git.netfilter.org/libmnl
+	url = git://git.netfilter.org/libmnl.git
 [submodule "libnftnl"]
 	path = libnftnl
-	url = git://git.netfilter.org/libnftnl
+	url = git://git.netfilter.org/libnftnl.git
 [submodule "win-split-tunnel"]
 	path = win-split-tunnel
 	url = https://github.com/mullvad/win-split-tunnel.git
 [submodule "wireguard-nt"]
 	path = wireguard-nt
-	url = https://github.com/mullvad/wireguard-nt
+	url = https://github.com/mullvad/wireguard-nt.git
 [submodule "libnl"]
 	path = libnl
-	url = https://github.com/thom311/libnl
+	url = https://github.com/thom311/libnl.git
 [submodule "apisocks5"]
 	path = apisocks5
 	url = https://github.com/mullvad/apisocks5.git


### PR DESCRIPTION
git.openssl.org has been down for several days now which has been preventing us on Solus from being able to build Mullvad. They do however have a GitHub "mirror" which actually appears to be the main development repository that is synced to git.openssl.org instead of the other way around. Since both the mullvadvpn-app and mullvadvpn-app-binaries repositories are also hosted on GitHub it makes more sense to use GitHub for OpenSSL as doing so drops a build-time dependency on an external host.

Also change the URLs of the other git submodules to end in `.git` for consistency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-binaries/115)
<!-- Reviewable:end -->
